### PR TITLE
Removes misleading docstrings and unused parameter

### DIFF
--- a/cask.py
+++ b/cask.py
@@ -1374,9 +1374,6 @@ class Object(object):
 
     def start_frame(self):
         """
-        :param fps: Frames per second used to calculate the start frame
-        (default 24.0)
-
         :return: Start frame as float
         """
         try:
@@ -1386,11 +1383,8 @@ class Object(object):
         except AttributeError:
             return self.parent.start_frame()
 
-    def end_frame(self, fps=24):
+    def end_frame(self):
         """
-        :param fps: Frames per second used to calculate the end frame
-        (default 24.0)
-
         :return: Last frame as float
         """
         try:


### PR DESCRIPTION
Some minor cleanup as well while I was poking around with FPS, noticed that there's a stale docstring, plus `end_frame` doesn't respect (or even care) about the fps param.