### PR TITLE
support copying timesampling objects to new archives

### DIFF
--- a/cask.py
+++ b/cask.py
@@ -42,7 +42,7 @@ into high level convenience methods.
 
 More information can be found at http://docs.alembic.io/python/cask.html
 """
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 import os
 import re
@@ -675,7 +675,7 @@ class Archive(object):
         """
         smps = []
         # look for timesampling data on the iarchive first
-        if self.iobject and not self.oobject:
+        if self.timesamplings or (self.iobject and not self.oobject):
             smps = [(i, ts) for i, ts in enumerate(self.timesamplings)]
         # is none exist, create a new one
         if not smps:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 #-******************************************************************************
 #
-# Copyright (c) 2012-2016,
+# Copyright (c) 2012-2017,
 #  Sony Pictures Imageworks Inc. and
 #  Industrial Light & Magic, a division of Lucasfilm Entertainment Company Ltd.
 #
@@ -50,7 +50,7 @@ def get_deps(*args):
 
 setup(
     name='cask',
-    version='1.0.0',
+    version='1.0.2',
     description='Cask - High level convenience wrapper for Alembic files',
     author='Ryan Galloway',
     author_email='ryang@ilm.com',

--- a/test/testCask.py
+++ b/test/testCask.py
@@ -1,6 +1,6 @@
 #-******************************************************************************
 #
-# Copyright (c) 2012-2016,
+# Copyright (c) 2012-2017,
 #  Sony Pictures Imageworks Inc. and
 #  Industrial Light & Magic, a division of Lucasfilm Entertainment Company Ltd.
 #
@@ -53,7 +53,6 @@ TEMPDIR = tempfile.mkdtemp()
 
 """
 TODO
- - add new TimeSampling objects to archives (empty and from disk)
  - more tests for getting and setting values/samples
  - test creating prototype schema objects
  - test name collisions when creating new objects and properties
@@ -1030,6 +1029,30 @@ class Test2_Read(unittest.TestCase):
         self.assertTrue("nurby" in d.children.keys())
         self.assertEqual(type(d.children["meshy"]), cask.Xform)
         self.assertEqual(type(d.children["nurby"]), cask.NuPatch)
+
+    def test_verify_copy_timesampling(self):
+        test_cube_out = cube_out("cask_test_copy_timesamplings_1.abc")
+        test_file_path = os.path.join(TEMPDIR, "cask_test_copy_timesamplings_2.abc")
+        self.assertTrue(cask.is_valid(test_cube_out))
+
+        a = cask.Archive(test_cube_out)
+
+        # create new archive and copy ts objects
+        b = cask.Archive()
+        b.timesamplings.extend(a.timesamplings[:])
+
+        self.assertEqual(len(a.timesamplings), len(b.timesamplings))
+        b.write_to_file(test_file_path)
+        b.close()
+
+        # verify the ts objects were written to the archive
+        c = cask.Archive(test_file_path)
+        self.assertEqual(len(a.timesamplings), len(c.timesamplings))
+        ts_a = a.timesamplings[-1]
+        ts_c = c.timesamplings[-1]
+        self.assertEqual(ts_a.getNumStoredTimes(), ts_c.getNumStoredTimes())
+        for i, t in enumerate(ts_a.getStoredTimes()):
+            self.assertEqual(t, ts_c.getStoredTimes()[i])
 
     def test_find(self):
         filename = os.path.join(TEMPDIR, "cask_write_mesh.abc")


### PR DESCRIPTION
This update is useful for when you want to copy an object from one archive to a new archive and the times need to match up with the source archive. Previously, cask was throwing an attribute error when trying to copy timesampling objects to new archives:

AttributeError: 'NoneType' object has no attribute 'getMaxNumSamplesForTimeSamplingIndex' 

With this update, users can simply copy the timesampling objects over from the source archive:

`>>> out_archive.timesamplings.extend(in_archive.timesamplings[:])`

All unit tests passing, including a new one added to test this feature.