### PR TITLE
Cask 1.1.1

### DIFF
--- a/cask.py
+++ b/cask.py
@@ -42,7 +42,7 @@ into high level convenience methods.
 
 More information can be found at http://docs.alembic.io/python/cask.html
 """
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 import os
 import re
@@ -1156,6 +1156,11 @@ class Property(object):
                     elif prop.parent.name == ".userProperties":
                         up = Property()
                         up._oobject = prop.object().oobject.getSchema().getUserProperties()
+                        up.properties[prop.name] = prop
+                        prop.parent = up
+                    elif prop.parent.name == ".arbGeomParams":
+                        up = Property()
+                        up._oobject = prop.object().oobject.getSchema().getArbGeomParams()
                         up.properties[prop.name] = prop
                         prop.parent = up
                 else:

--- a/cask.py
+++ b/cask.py
@@ -259,7 +259,8 @@ POD_EXTENT = {
     Int64: (alembic.Util.POD.kInt64POD, -1),
     float: (alembic.Util.POD.kFloat64POD, -1),
     str: (alembic.Util.POD.kStringPOD, -1),
-    imath.V3f: (alembic.Util.POD.kFloat32POD, -1),
+    imath.V3f: (alembic.Util.POD.kFloat32POD, 3),
+    imath.V3d: (alembic.Util.POD.kFloat64POD, 3),
     imath.Color3c: (alembic.Util.POD.kUint8POD, -1),
     imath.Color3f: (alembic.Util.POD.kFloat32POD, -1),
     imath.Color4c: (alembic.Util.POD.kUint8POD, -1),
@@ -273,6 +274,8 @@ POD_EXTENT = {
     imath.StringArray: (alembic.Util.POD.kStringPOD, -1),
     imath.UnsignedCharArray: (alembic.Util.POD.kUint8POD, -1),
     imath.IntArray: (alembic.Util.POD.kInt32POD, -1),
+    imath.V3fArray: (alembic.Util.POD.kFloat32POD, 3),
+    imath.V3dArray: (alembic.Util.POD.kFloat64POD, 3),
     imath.FloatArray: (alembic.Util.POD.kFloat32POD, -1),
     imath.DoubleArray: (alembic.Util.POD.kFloat64POD, -1),
 }
@@ -331,6 +334,7 @@ def get_pod_extent(prop):
         pod, extent = POD_EXTENT.get(type(value0))
     except TypeError as err:
         print "Error getting pod, extent from", prop, value0
+        print err
         return (alembic.Util.POD.kUnknownPOD, 1)
     if extent <= 0:
        extent = (len(value0)

--- a/cask.py
+++ b/cask.py
@@ -239,6 +239,7 @@ IMATH_ARRAYS_BY_TYPE = {
     Int8: imath.SignedCharArray,
     Int16: imath.ShortArray,
     Int32: imath.IntArray,
+    Int64: imath.DoubleArray,
     Uint8: imath.UnsignedCharArray,
     Uint16: imath.UnsignedShortArray,
     Uint32: imath.UnsignedIntArray
@@ -294,6 +295,8 @@ def get_simple_oprop_class(prop):
     value = prop.values[0] if len(prop.values) > 0 else []
     if prop.iobject:
         is_array = prop.iobject.isArray()
+    elif type(value) in IMATH_ARRAYS_VALUES:
+        is_array = True
     else:
         is_array = type(value) in [list, set] and len(value) > 1
     if is_array:

--- a/test/testCask.py
+++ b/test/testCask.py
@@ -53,7 +53,6 @@ TEMPDIR = tempfile.mkdtemp()
 
 """
 TODO
- - more tests for getting and setting values/samples
  - test creating prototype schema objects
  - test name collisions when creating new objects and properties
 """
@@ -706,7 +705,7 @@ class Test1_Write(unittest.TestCase):
         something = foo.properties["something"]
 
         # assert pod, extent values
-        self.assertEqual(bar.extent(), 5)
+        self.assertEqual(bar.extent(), 1)
         self.assertEqual(bar.pod(), alembic.Util.POD.kUint8POD)
         self.assertEqual(bar.values[0], v)
         self.assertEqual(baz.extent(), 1)
@@ -850,7 +849,6 @@ class Test2_Read(unittest.TestCase):
     def test_read_mesh(self):
         filepath = mesh_out()
         self.assertTrue(cask.is_valid(filepath))
-        print filepath
         a = cask.Archive(filepath)
         t = a.top
 
@@ -1347,8 +1345,26 @@ class Test3_Issues(unittest.TestCase):
         a.top.children["foo"] = cask.Xform()
         p1 = a.top.children["foo"].properties["p1"] = cask.Property()
         p2 = a.top.children["foo"].properties["p2"] = cask.Property()
-        p1.set_value(imath.UnsignedCharArray(6))
-        p2.set_value(imath.DoubleArray(12))
+        p3 = a.top.children["foo"].properties["p3"] = cask.Property()
+        p4 = a.top.children["foo"].properties["p4"] = cask.Property()
+
+        ca = imath.UnsignedCharArray(6)
+        for i in range(6):
+            ca[i] = i
+        p1.set_value(ca)
+
+        da = imath.DoubleArray(12)
+        for i in range(12):
+            da[i] = i * 3.0
+        p2.set_value(da)
+
+        va = imath.V3fArray(3)
+        for i in range(3):
+            va[i] = imath.V3f(i, i*2.0, i*3.0)
+        p3.set_value(va)
+
+        p4.set_value([imath.V3f(1, 2, 3), imath.V3f(4, 5, 6), imath.V3f(7, 8, 9)])
+
         a.write_to_file(test_file_1)
         a.close()
 
@@ -1356,8 +1372,12 @@ class Test3_Issues(unittest.TestCase):
         a = cask.Archive(test_file_1)
         p1 = a.top.children["foo"].properties["p1"]
         p2 = a.top.children["foo"].properties["p2"]
-        self.assertTrue(p1.iobject.isScalar())
-        self.assertTrue(p2.iobject.isScalar())
+        p3 = a.top.children["foo"].properties["p3"]
+        p4 = a.top.children["foo"].properties["p4"]
+        self.assertTrue(p1.iobject.isArray())
+        self.assertTrue(p2.iobject.isArray())
+        self.assertTrue(p3.iobject.isArray())
+        self.assertTrue(p4.iobject.isArray())
         a.close()
 
     def test_issue_8(self):
@@ -1372,30 +1392,18 @@ class Test3_Issues(unittest.TestCase):
         p1 = m.properties[".geom/.arbGeomParams/test"] = cask.Property()
         p1.set_value("somevalue")
 
-        p2 = m.properties[".geom/.arbGeomParams/rotation"] = cask.Property()
-        p2.set_value([imath.V3f(1, 2, 3), imath.V3f(4, 5, 6), imath.V3f(7, 8, 9)])
-
-        self.assertEqual(p2.pod(), alembic.Util.POD.kFloat32POD)
-        self.assertEqual(p2.extent(), 3)
-
         a.write_to_file(test_file_1)
         a.close()
 
         a1 = cask.Archive(test_file_1)
         m1 = a1.top.children["meshy"]
         self.assertTrue("test" in m1.properties[".geom/.arbGeomParams"].properties)
-        self.assertTrue("rotation" in m1.properties[".geom/.arbGeomParams"].properties)
 
         self.assertEqual(m1.properties[".geom/.arbGeomParams/test"].values[0],
                 "somevalue")
-        
-        p2 = m1.properties[".geom/.arbGeomParams/rotation"]
-        self.assertEqual(p2.pod(), alembic.Util.POD.kFloat32POD)
-        self.assertEqual(p2.extent(), 3)
-        self.assertEqual(type(p2.values[0]), imath.V3fArray)
-        self.assertEqual(p2.values[0][0], imath.V3f(1, 2, 3))
-        self.assertEqual(p2.values[0][1], imath.V3f(4, 5, 6))
-        self.assertEqual(p2.values[0][2], imath.V3f(7, 8, 9))
+
+        a1.close()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/testCask.py
+++ b/test/testCask.py
@@ -850,6 +850,7 @@ class Test2_Read(unittest.TestCase):
     def test_read_mesh(self):
         filepath = mesh_out()
         self.assertTrue(cask.is_valid(filepath))
+        print filepath
         a = cask.Archive(filepath)
         t = a.top
 
@@ -1367,17 +1368,34 @@ class Test3_Issues(unittest.TestCase):
 
         a = cask.Archive()
         m = a.top.children["meshy"] = cask.PolyMesh()
-        p = m.properties[".geom/.arbGeomParams/test"] = cask.Property()
-        p.set_value("somevalue")
+
+        p1 = m.properties[".geom/.arbGeomParams/test"] = cask.Property()
+        p1.set_value("somevalue")
+
+        p2 = m.properties[".geom/.arbGeomParams/rotation"] = cask.Property()
+        p2.set_value([imath.V3f(1, 2, 3), imath.V3f(4, 5, 6), imath.V3f(7, 8, 9)])
+
+        self.assertEqual(p2.pod(), alembic.Util.POD.kFloat32POD)
+        self.assertEqual(p2.extent(), 3)
+
         a.write_to_file(test_file_1)
         a.close()
 
         a1 = cask.Archive(test_file_1)
         m1 = a1.top.children["meshy"]
         self.assertTrue("test" in m1.properties[".geom/.arbGeomParams"].properties)
+        self.assertTrue("rotation" in m1.properties[".geom/.arbGeomParams"].properties)
+
         self.assertEqual(m1.properties[".geom/.arbGeomParams/test"].values[0],
                 "somevalue")
-
+        
+        p2 = m1.properties[".geom/.arbGeomParams/rotation"]
+        self.assertEqual(p2.pod(), alembic.Util.POD.kFloat32POD)
+        self.assertEqual(p2.extent(), 3)
+        self.assertEqual(type(p2.values[0]), imath.V3fArray)
+        self.assertEqual(p2.values[0][0], imath.V3f(1, 2, 3))
+        self.assertEqual(p2.values[0][1], imath.V3f(4, 5, 6))
+        self.assertEqual(p2.values[0][2], imath.V3f(7, 8, 9))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/testCask.py
+++ b/test/testCask.py
@@ -1359,5 +1359,25 @@ class Test3_Issues(unittest.TestCase):
         self.assertTrue(p2.iobject.isScalar())
         a.close()
 
+    def test_issue_8(self):
+        """creating arbGeomParams on geom objects
+        https://github.com/alembic/cask/issues/8"""
+
+        test_file_1 = os.path.join(TEMPDIR, "cask_test_issue_8.abc")
+
+        a = cask.Archive()
+        m = a.top.children["meshy"] = cask.PolyMesh()
+        p = m.properties[".geom/.arbGeomParams/test"] = cask.Property()
+        p.set_value("somevalue")
+        a.write_to_file(test_file_1)
+        a.close()
+
+        a1 = cask.Archive(test_file_1)
+        m1 = a1.top.children["meshy"]
+        self.assertTrue("test" in m1.properties[".geom/.arbGeomParams"].properties)
+        self.assertEqual(m1.properties[".geom/.arbGeomParams/test"].values[0],
+                "somevalue")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Second update inside a week, I guess...

- This fixes alembic/cask#8, creating properties under .arbGeomParams in cask. 
- It also addresses existing bugs when exporting imath Array values, also mentioned in #8 
- Adds unit tests for the above.

Previously, users would get an error exporting a V3fArray, so it couldn't be done. This fixes that, and also changes all imath Array types to ArrayProperties, when previously for example, UnsignedCharArray values were exported as Scalar. 
